### PR TITLE
fix: remove unimplemented form processing placeholder from POST response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,14 @@
 webserv
 debugme
 
-# Local environment files
-.vscode
-*.pdf
+# Editors and IDEs 
+.vscode/
+*.swp
+tags
+
+# 42 Intelectual Property
+*subject*
+
+# Uploaded files
+www/uploads/*
+

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,10 @@ re: fclean all
 debug:
 	@make WITH_DEBUG=TRUE --no-print-directory
 
+run: all
+	./$(NAME)
+
 # Include dependency files
 -include $(DEP)
 
-.PHONY: all clean fclean re debug
+.PHONY: all clean fclean re debug run

--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ server {
 - [x] Project setup and repository initialization
 - [x] Configuration file parsing
 - [x] Socket management and non-blocking I/O
-- [ ] HTTP request parsing
-- [ ] HTTP response generation
-- [ ] Static file serving
-- [ ] Directory listing
-- [ ] Error handling
-- [ ] CGI implementation
-- [ ] File upload handling
+- [x] HTTP request parsing
+- [x] HTTP response generation
+- [x] Static file serving
+- [x] Directory listing
+- [x] Error handling
+- [x] CGI implementation
+- [x] File upload handling
 - [ ] Testing and documentation
 
 ## 🧪 Testing
@@ -134,6 +134,9 @@ The server can be tested using:
 
 ## 👥 Contributors
 - [jos-felipe](https://github.com/jos-felipe)
+- [Adedayo-Sanni](https://github.com/Adedayo-Sanni)
+- [Thiagosdcavalcante](https://github.com/Thiagosdcavalcante)
 
 ## 📄 License
 This project is part of the School 42 curriculum.
+

--- a/include/HttpRequest.hpp
+++ b/include/HttpRequest.hpp
@@ -97,11 +97,8 @@ private:
 	HttpResponse						handleGet(const LocationConfig& location, 
 												HttpResponse& response, const Config& config);
 	
-	/**
-	 * Handle POST request for file uploads
-	 */
-	HttpResponse						handlePost(const LocationConfig& location, 
-												HttpResponse& response, const Config& config);
+	HttpResponse handlePost(LocationConfig const &location, 
+		HttpResponse &response, Config const &config);
 	
 	/**
 	 * Handle DELETE request for file deletion
@@ -132,11 +129,7 @@ private:
 	HttpResponse						handleFileUpload(const LocationConfig& location, 
 													HttpResponse& response, const Config& config);
 	
-	/**
-	 * Handle application/x-www-form-urlencoded data
-	 */
-	HttpResponse						handleFormData(const LocationConfig& location, 
-													HttpResponse& response, const Config& config);
+	HttpResponse handleFormData(HttpResponse &response); 
 	
 	/**
 	 * Handle CGI request execution

--- a/src/http/HttpRequest.cpp
+++ b/src/http/HttpRequest.cpp
@@ -634,27 +634,22 @@ HttpResponse	HttpRequest::handleGet(const LocationConfig& location,
 	return response;
 }
 
-/**
- * Handle POST request for file uploads
- */
-HttpResponse	HttpRequest::handlePost(const LocationConfig& location, 
-	HttpResponse& response, const Config& config)
-{
+HttpResponse HttpRequest::handlePost(LocationConfig const &location, 
+	HttpResponse& response, Config const &config) {
 	std::cout << "DEBUG: Handling POST request for " << _path << std::endl;
 	
 	// Build the full file path to check for CGI
 	std::string fullPath = location.root + _path;
 	
 	// Check if this is a CGI request
-	if (CgiHandler::isCgiFile(fullPath, location))
-	{
-		std::cout << "DEBUG: Detected CGI file, delegating to CGI handler" << std::endl;
+	if (CgiHandler::isCgiFile(fullPath, location)) {
+		std::cout << "DEBUG: Detected CGI file, delegating to CGI handler" << 
+		std::endl;
 		return handleCgi(location, response, config);
 	}
 	
 	// Check if upload is allowed for this location
-	if (location.uploadStore.empty())
-	{
+	if (location.uploadStore.empty()) {
 		std::cout << "DEBUG: Upload not allowed for this location" << std::endl;
 		response.setStatus(403);
 		response.setBody(config.getDefaultErrorPage(403));
@@ -664,16 +659,14 @@ HttpResponse	HttpRequest::handlePost(const LocationConfig& location,
 	// Parse Content-Type header to handle multipart/form-data
 	std::string contentType = getHeader("Content-Type");
 	
-	if (contentType.find("multipart/form-data") != std::string::npos)
-	{
+	if (contentType.find("multipart/form-data") != std::string::npos) {
 		return handleFileUpload(location, response, config);
 	}
-	else if (contentType.find("application/x-www-form-urlencoded") != std::string::npos)
-	{
-		return handleFormData(location, response, config);
+	else if (contentType.find("application/x-www-form-urlencoded") !=
+	std::string::npos) {
+		return handleFormData(response);
 	}
-	else
-	{
+	else {
 		// Simple file upload - treat body as raw file content
 		std::ostringstream oss;
 		oss << "upload_" << time(NULL);
@@ -681,9 +674,9 @@ HttpResponse	HttpRequest::handlePost(const LocationConfig& location,
 		std::string uploadPath = location.uploadStore + "/" + filename;
 		
 		std::ofstream file(uploadPath.c_str(), std::ios::binary);
-		if (!file.is_open())
-		{
-			std::cout << "DEBUG: Failed to create upload file: " << uploadPath << std::endl;
+		if (!file.is_open()) {
+			std::cout << "DEBUG: Failed to create upload file: " << 
+			uploadPath << std::endl;
 			response.setStatus(500);
 			response.setBody(config.getDefaultErrorPage(500));
 			return response;
@@ -979,20 +972,11 @@ HttpResponse	HttpRequest::handleFileUpload(const LocationConfig& location,
 	return response;
 }
 
-/**
- * Handle application/x-www-form-urlencoded data
- */
-HttpResponse	HttpRequest::handleFormData(const LocationConfig& location, 
-	HttpResponse& response, const Config& config)
-{
-	(void)location; // Unused parameter
-	(void)config;   // Unused parameter
-	
+HttpResponse HttpRequest::handleFormData(HttpResponse &response) {
 	std::cout << "DEBUG: Handling form data" << std::endl;
 	
 	response.setStatus(200);
 	response.setBody("<html><body><h1>Form Data Received</h1>"
-	                "<p>Form processing not yet implemented.</p>"
 	                "<p>Received " + _body + "</p>"
 	                "</body></html>");
 	response.addHeader("Content-Type", "text/html");


### PR DESCRIPTION
## Problem
An internal development message - Form processing not yet implemented - leaked
to POST response body.

## Root Cause Analysis
A placeholder for form processing was injected as a messege in the html for POST
response body during the prototyping phase.

## Solution Implemented
Form processing functionality will not be implemented as it falls outside the
defined project scope. Removing the placeholder message eliminates user
confusion and ensures the application accurately represents its actual
capabilities rather than suggesting unimplemented features."

## How to Test
1. Run ```bash make run``` to compile and execute the Webserv with default config
2. Run ```bash curl -v -X POST -d "this is a test" http://localhost:8080/```
3. Check that there is no mention of form processing
3. Verify that the response includes the echoed data and return approprieate
HTTP status codes, confirming that removing the placeholder didn't break the
underlying functionality."
### User Interface Compatibility 
1. Navigate to http://localhost:8080/upload.html
2. Enter "this is a test" in Simple POST Data box and click on 'Send Data'
3. Check that 'this is a test' was echoed and there is no mention of form
processing

